### PR TITLE
reafactor: remove player size into story decorator

### DIFF
--- a/src/ui/MoviePlayer/MoviePlayer.module.scss
+++ b/src/ui/MoviePlayer/MoviePlayer.module.scss
@@ -4,8 +4,6 @@ $white: #ffffff;
 
 .playerContainer {
   position: relative;
-  max-width: fn.toRem(745px);
-  height: fn.toRem(405px);
   overflow: hidden;
 }
 

--- a/src/ui/MoviePlayer/MoviePlayer.stories.tsx
+++ b/src/ui/MoviePlayer/MoviePlayer.stories.tsx
@@ -41,4 +41,17 @@ export const Default: Story = {
     name: 'Большой самоуверенный кролик',
     text: 'Ролик',
   },
+  decorators: [
+    (Story) => {
+      return (
+        <div
+          style={{
+            width: 745,
+          }}
+        >
+          <Story />
+        </div>
+      )
+    },
+  ],
 }


### PR DESCRIPTION
Небольшой рефакторинг. Переместил размеры видеоплеера в декоратор сторибука, т.е. теперь видеоплеер зависит от размеров тега-обертки.